### PR TITLE
fix multiprocessing bug

### DIFF
--- a/utils/commons/multiprocess_utils.py
+++ b/utils/commons/multiprocess_utils.py
@@ -120,7 +120,7 @@ def multiprocess_run(map_func, args, num_workers=None, ordered=True, init_ctx_fu
         for job_i, res in manager.get_results():
             results[job_i] = res
             while i_now < n_jobs and (not isinstance(results[i_now], str) or results[i_now] != '<WAIT>'):
-                yield job_i, results[i_now]
+                yield i_now, results[i_now]
                 results[i_now] = None
                 i_now += 1
     else:


### PR DESCRIPTION
Hi @RayeRen, today I've tried your `preprocess.py` code for LJSpeech dataset. And I realized that there were some processed items in `metadata.json` doesn't have `ph_token` key or `len(ph.split())` is not equal to `len(ph_token)`. So I've checked your code and found the problem with the line 123 in `utils/commons/multiprocess_utils.py`.

https://github.com/NATSpeech/NATSpeech/blob/e7e68d68f3ee70c8d13a1d689b6d69b79331825d/utils/commons/multiprocess_utils.py#L120-L125

For my understanding, you tried to return the indices and results as passed order instead of processed order, so I think `i_now` should be yielded instead of `job_i`. I also code a small snippet to debug your code, you can use it as reference.

```python
def test_map_func(idx):
    import time
    time.sleep(0.2)
    return {"number": idx*2, "id": idx}

if __name__ == "__main__":
    args = [{"idx": idx} for idx in range(100)]
    ids = []
    for idx, x in multiprocess_run_tqdm(test_map_func, args):
        # args[idx].update(x)
        ids.append(idx)
   print(ids) 
   # print [0, 1, 2, 3, 4, 5, 5, 7, 7, 7, 7, 7, ...] with yield job_i
   # print [0, 1, 2, 3, 4, 6, 7, 8, 9, 10, ...] with yield i_now
```